### PR TITLE
Adding Kabsch rotation - optimal RMSD for loss/metrics computing 

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -25,7 +25,90 @@ def shape_and_backend(x,y,backend):
     return x,y,backend
 
 
+# alignment
+
+def kabsch_torch(X, Y):
+    """ Kabsch alignment of X with Y as reference. 
+        Assumes x,y are both (B x D x N). See below for wrapper.
+    """
+    raise NotImplementedError("Torch backend not yet implemented")
+    return X_, Y_
+
+def kabsch_numpy(X, Y):
+    """ Kabsch alignment of X with Y as reference. 
+        Assumes x,y are both (B x D x N). See below for wrapper.
+    """
+
+    return X_, Y_
+
+
 # metrics - more formulas here: http://predictioncenter.org/casp12/doc/help.html
+
+def rmsd_torch(X, Y):
+    """ Assumes x,y are both (B x D x N). See below for wrapper. """
+    return torch.sqrt( torch.mean((X - Y)**2, axis=(-1, -2)) )
+
+def rmsd_numpy(X, Y):
+    """ Assumes x,y are both (B x D x N). See below for wrapper. """
+    return np.sqrt( np.mean((X - Y)**2, axis=(-1, -2)) )
+
+def gdt_torch(X, Y, cutoffs, weights=None):
+    """ Assumes x,y are both (B x D x N). see below for wrapper.
+        * cutoffs is a list of `K` thresholds
+        * weights is a list of `K` weights (1 x each threshold)
+    """
+    if weights is None:
+        weights = torch.ones(1,len(weights))
+    else:
+        weights = torch.tensor([weights]).to(x.device)
+    # set zeros and fill with values
+    GDT = torch.zeros(X.shape[0], len(cutoffs), device=X.device) 
+    dist = ((X - Y)**2).sum(dim=1).sqrt()
+    # iterate over thresholds
+    for i,cutoff in enumerate(cutoffs):
+        GDT[:, i] = (dist <= cutoff).float().sum(dim=-1)
+    # weighted mean
+    return (GDT*weights).mean(-1)
+
+def gdt_numpy(X, Y, cutoffs, weights=None):
+    """ Assumes x,y are both (B x D x N). see below for wrapper.
+        * cutoffs is a list of `K` thresholds
+        * weights is a list of `K` weights (1 x each threshold)
+    """
+    if weights is None
+        weights = np.ones( (1,len(weights)) )
+    else:
+        weights = np.array([weights])
+    # set zeros and fill with values
+    GDT = torch.zeros( (X.shape[0], len(cutoffs)) )
+    dist = ((X - Y)**2).sum(axis=1).sqrt()
+    # iterate over thresholds
+    for i,cutoff in enumerate(cutoffs):
+        GDT[:, i] = (dist <= cutoff).float().sum(axis=-1)
+    # weighted mean
+    return (GDT*weights).mean(-1)
+
+def tmscore_torch(X, Y):
+    """ Assumes x,y are both (B x D x N). see below for wrapper. """
+    L = X.shape[-1]
+    d0 = 1.24 * np.cbrt(L - 15) - 1.8
+    # get distance
+    dist = ((X - Y)**2).sum(dim=1).sqrt()
+    # formula (see wrapper for source): 
+    return (1 / (1 + (dist/d0)**2)).mean(dim=-1)
+
+def tmscore_numpy(X, Y):
+    """ Assumes x,y are both (B x D x N). see below for wrapper. """
+    L = X.shape[-1]
+    d0 = 1.24 * np.cbrt(L - 15) - 1.8
+    # get distance
+    dist = np.sqrt( ((X - Y)**2).sum(axis=1) )
+    # formula (see wrapper for source): 
+    return (1 / (1 + (dist/d0)**2)).mean(axis=-1)
+
+################
+### WRAPPERS ###
+################
 
 def RMSD(A, B, backend="auto"):
     """ Returns RMSD score as defined here (lower is better):
@@ -39,12 +122,12 @@ def RMSD(A, B, backend="auto"):
     A, B, backend = shape_and_backend(A, B, backend)
     # run calcs
     if backend == "torch":
-        return torch.sqrt( torch.mean((A - B)**2, axis=(-1, -2)) )
+        return rmsd_torch(A, B)
     else:
-        return np.sqrt( np.mean((A - B)**2, axis=(-1, -2)) )
+        return rmsd_numpy(A, B)
 
 
-def GDT(A,B, mode="TS", cutoffs=[1,2,4,8], weights=None, mode="auto"):
+def GDT(A,B, mode="TS", cutoffs=[1,2,4,8], weights=None, backend="auto"):
     """ Returns GDT score as defined here (highre is better):
         Supports both TS and HA
         http://predictioncenter.org/casp12/doc/help.html
@@ -58,53 +141,30 @@ def GDT(A,B, mode="TS", cutoffs=[1,2,4,8], weights=None, mode="auto"):
     A, B, backend = shape_and_backend(A, B, backend)
     # define cutoffs for each type of gdt and weights
     cutoffs = [0.5,1,2,4] if func == "HA" else [1,2,4,8]
-    if weights is None:
-        if mode == "torch":
-            weights = torch.ones(1,len(weights))
-        else:
-            weights = np.ones((1,len(weights)))
-    else: 
-        if mode == "torch":
-            weights = torch.tensor([weights]).to(A.device)
-        else:
-            weights = np.array([weights])
     # calculate GDT
     if mode == "torch":
-        GDT  = torch.zeros(A.shape[0], len(cutoffs), device=A.device) 
-        dist = ((A - B)**2).sum(dim=1).sqrt()
-        # iterate over thresholds
-        for i,cutoff in enumerate(cutoffs):
-            GDT[:, i] = (dist <= cutoff).float().sum(dim=-1)
+        return gdt_torch(A, B, cutoffs, weights=weights)
     else:
-        GDT = np.zeros((A.shape[0], len(cutoffs))) 
-        dist = np.sqrt((A - B)**2).sum(dim=1)
-        # iterate over thresholds
-        for i,cutoff in enumerate(cutoffs):
-            GDT[:, i] = (dist <= cutoff).sum(dim=-1)
-
-    # assign weights and take meanb.d
-    return (GDT*weights).mean(-1)
+        return gdt_numpy(A, B, cutoffs, weights=weights)
 
 
 def TMscore(A,B,backend="auto"):
     """ Returns TMscore as defined here (higher is better):
         >0.5 (likely) >0.6 (highly likely) same folding. 
-        = 0.2
-        https://en.wikipedia.org/wiki/Template_modeling_score
+        = 0.2. https://en.wikipedia.org/wiki/Template_modeling_score
+        Warning! It's not exactly the code in:
+        https://zhanglab.ccmb.med.umich.edu/TM-score/TMscore.cpp
+        but will suffice for now. 
         Inputs: 
             * A,B are (B x 3 x N) (np.array or torch.tensor)
             * mode: one of ["numpy", "torch", "auto"] for backend
         Outputs: tensor/array of size (B,)
     """
     A, B, backend = shape_and_backend(A, B, backend)
-    # params and distances
-    L = A.shape[-1]
-    d0 = 1.24 * np.cbrt(L - 15) - 1.8
+    # run calcs
     if backend == "torch":
-        dist = ((A - B)**2).sum(dim=1).sqrt()
+        return tmscore_torch(A, B)
     else:
-        dist = np.sqrt((A - B)**2).sum(dim=1)
-    # return calc by formula
-    return (1 / (1 + (dist/d0)**2)).mean(-1)
+        return tmscore_numpy(A, B)
 
 


### PR DESCRIPTION
Added centering and rotation so that point-wise losses/metrics can be calculated wrt 3D (or N-d) point clouds.

Implementations in both numpy and torch so should allow end2end loss. Will test it all together once i have a naive MDS working.