### PR TITLE
Adds point cloud utils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,8 @@ setup(
     'einops>=0.3',
     'numpy',
     'torch>=1.6',
-    'mdtraj>=1.8'
+    'mdtraj>=1.8',
+    'se3-transformer-pytorch'
   ],
   classifiers=[
     'Development Status :: 4 - Beta',

--- a/train_end2end.py
+++ b/train_end2end.py
@@ -115,8 +115,6 @@ for _ in range(NUM_BATCHES):
 
         # predict
         distogram = model(seq, msa = msa, embedds = embedds, mask = mask)
-        distogram = distogram[:, mask]
-        distogram = distogram[:, :, mask]
 
         # convert to 3d
         N_mask, CA_mask = scn_backbone_mask(seq)

--- a/train_end2end.py
+++ b/train_end2end.py
@@ -3,17 +3,17 @@ from torch.optim import Adam
 from torch.utils.data import DataLoader
 import torch.nn.functional as F
 from einops import rearrange
-
+# data
 import sidechainnet as scn
 from sidechainnet.sequence.utils import VOCAB
-
+# models
 from alphafold2_pytorch import Alphafold2, DISTOGRAM_BUCKETS
 from utils import *
 
 
 # constants
 
-FEATURES = "esm" # one of ["esm", "msa"]
+FEATURES = "esm" # one of ["esm", "msa", None]
 DEVICE = None # defaults to cuda if available, else cpu
 NUM_BATCHES = int(1e5)
 GRADIENT_ACCUMULATE_EVERY = 16
@@ -76,6 +76,7 @@ model = Alphafold2(
     dim_head = 64
 ).to(DEVICE)
 
+
 # optimizer 
 dispersion_weight = 0.1
 criterion = nn.MSELoss()
@@ -88,35 +89,39 @@ for _ in range(NUM_BATCHES):
         _, seq, _, mask, *_, coords = next(dl)
         b, l = seq.shape
 
-        # prepare mask, labels
+        # prepare data and mask labels
 
         seq, coords, mask = seq.to(DEVICE), coords.to(DEVICE), mask.to(DEVICE).bool()
-        coords = rearrange(coords, 'b (l c) d -> b l c d', l = l)
+        # mask the atoms for each residue
+        cloud_mask = scn_cloud_mask(seq, bool=True)
 
-        # sequence embedding (msa / esm)
+
+        # sequence embedding (msa / esm / attn / or nothing)
+        msa, embedds = None
+        # get embedds
         if FEATURES == "esm":
-            # set no msa
-            msa = None
-            # get embeddss
             str_seq = "".join([VOCAB._int2char[x]for x in seq.cpu().numpy()])
             data = [(0, str_seq)]
             batch_labels, batch_strs, batch_tokens = batch_converter(data)
             with torch.no_grad():
                 results = model(batch_tokens, repr_layers=[33], return_contacts=False)
-            embedds = results["representations"][33]
-                
+            embedds = results["representations"][33].to(DEVICE)
+        # get msa here
+        elif FEATURES == "msa":
+            pass 
+        # no embeddings 
         else:
-            # set embdedds
-            embedds = None
-            # get msa here
-            msa = None
+            pass
 
         # predict
         distogram = model(seq, msa = msa, embedds = embedds, mask = mask)
+        distogram = distogram[:, mask]
+        distogram = distogram[:, :, mask]
 
         # convert to 3d
-        N_mask, CA_mask = scn_seq_mask(seq)
-        distances, dispersion, weights = center_distogram_torch(distogram)
+        N_mask, CA_mask = scn_backbone_mask(seq)
+        distances, weights = center_distogram_torch(distogram)
+
 
         coords_3d = MDScaling(distances, 
             weights,
@@ -124,18 +129,22 @@ for _ in range(NUM_BATCHES):
             fix_mirror = 5, 
             N_mask = N_mask,
             CA_mask = CA_mask
-        ) 
+        ) # (3, N)
+        coords_3d = rearrange(coords_3d, 'd n -> () n d')
+
+        # # TODO: build whole sidechain
+        # sidechain_3d = build_sidechain(coords_3d)
+        cloud_mask = rearrange(cloud_mask, 'b l c -> b (l c)', l = l)
 
         # refine
-
-        # TODO: coords_align = refiner(coords_align)
+        # refined = refiner(coords_3d[cloud_mask]) # (1, N, 3)
 
         # rotate / align
-
-        coords_aligned = Kabsch(coords_3d, coords)
+        coords_aligned = Kabsch(refined, scaffold[cloud_mask])
 
         # loss
-        loss = torch.sqrt(criterion(coords_aligned, coords)) + dispersion_weight * torch.norm(dispersion)
+        loss = torch.sqrt(criterion(coords_aligned[mask], coords[mask])) + \
+               dispersion_weight * torch.norm( (1/weights)-1 )
 
         loss.backward()
 

--- a/train_pre.py
+++ b/train_pre.py
@@ -83,7 +83,7 @@ for _ in range(NUM_BATCHES):
         seq, coords, mask = seq.to(DEVICE), coords.to(DEVICE), mask.to(DEVICE).bool()
         coords = rearrange(coords, 'b (l c) d -> b l c d', l = l)
 
-        discretized_distances = get_bucketed_distance_matrix(coords, mask)
+        discretized_distances = get_bucketed_distance_matrix(coords[:, :, 0], mask)
 
         # predict
 


### PR DESCRIPTION
Mods introduced: 
* minor fixes to shapes in the `utils.py` functions
* adds se3 as package requirement (not implemented yet in training codes)
* adds point cloud masking utils
* organizes better the msa/esm/... options
* gets a naïve `train_pre.py` working (only pick 1st atom of every aa to make it work)
* highlights the need for predicting >1 atom/aa (current setting is 1 point / aa).
    * some options:
        * whole aa (up to 14 points / aa which will be masked afterwards )
        * predict backbone and build sidechain assuming tetrahedral geometry (like they do in sidechainnet with dihedrals but with distances instead )  then pass to refinement