### PR TITLE
Fixes esm model name, Adds se3 , wrapper for sidechain, input elongation

### DIFF
--- a/alphafold2_pytorch/alphafold2.py
+++ b/alphafold2_pytorch/alphafold2.py
@@ -145,6 +145,7 @@ class Alphafold2(nn.Module):
         depth = 6,
         heads = 8,
         dim_head = 64,
+        pos_token = 3,
         num_tokens = NUM_AMINO_ACIDS,
         num_embedds = NUM_EMBEDDS_TR,
         attn_dropout = 0.,
@@ -189,8 +190,10 @@ class Alphafold2(nn.Module):
     def forward(self, seq, msa = None, embedds = None, mask = None, msa_mask = None):
         n, device = seq.shape[1], seq.device
 
+        # unpack (AA_cod, atom_pos)
+        if isinstance(seq, list):
+            seq, seq_pos = seq
         # embed main sequence
-
         x = self.token_emb(seq)
         x += self.pos_emb(torch.arange(n, device = device))[None, ...]
         x = x[:, :, None, :] + x[:, None, :, :] # create pair-wise residue embeds

--- a/train_end2end.py
+++ b/train_end2end.py
@@ -53,6 +53,13 @@ def cycle(loader, cond = lambda x: True):
                 continue
             yield data
 
+def get_esm_embedd(seq):
+    str_seq = "".join([VOCAB._int2char[x]for x in seq.cpu().numpy()])
+    batch_labels, batch_strs, batch_tokens = batch_converter( [(0, str_seq)] )
+    with torch.no_grad():
+        results = embedd_model(batch_tokens, repr_layers=[33], return_contacts=False)
+    return results["representations"][33].to(DEVICE)
+
 # get data
 
 data = scn.load(
@@ -72,6 +79,7 @@ dl = cycle(data, data_cond)
 
 model = Alphafold2(
     dim = 256,
+    pos_tokens = 3, # N-term, C-alpha, C-term
     depth = 1,
     heads = 8,
     dim_head = 64
@@ -103,27 +111,22 @@ for _ in range(NUM_BATCHES):
 
         # prepare data and mask labels
 
-        seq, coords, mask = seq.to(DEVICE), coords.to(DEVICE), mask.to(DEVICE).bool()
+        seq, coords, mask = seq.to(DEVICE), coords.to(DEVICE), mask.to(DEVICE)
         # coords = rearrange(coords, 'b (l c) d -> b l c d', l = l) # no need to rearrange for now
         # mask the atoms and backbone positions for each residue
         N_mask, CA_mask = scn_backbone_mask(seq, bool = True, l_aa = 3) # NUM_COORDS_PER_RES
-        cloud_mask = scn_cloud_mask(seq, bool = False)
-        mask = mask*cloud_mask
-        # flatten last dims for point cloud masking
-        mask = rearrange(mask, 'b l c -> b (l c)', l = l).bool()
+        cloud_mask = scn_cloud_mask(seq, bool = False, current_mask = mask)
+        # flatten last dims for point cloud maskinga and chain masking (cloud and sidechainnet). 
+        chain_mask = (mask * cloud_mask)
         cloud_mask = rearrange(cloud_mask, 'b l c -> b (l c)', l = l).bool()
-
+        chain_mask = rearrange(chain_mask, 'b l c -> b (l c)', l = l).bool()
+        chain_mask = chain_mask[cloud_mask]
 
         # sequence embedding (msa / esm / attn / or nothing)
         msa, embedds = None
         # get embedds
         if FEATURES == "esm":
-            str_seq = "".join([VOCAB._int2char[x]for x in seq.cpu().numpy()])
-            data = [(0, str_seq)]
-            batch_labels, batch_strs, batch_tokens = batch_converter(data)
-            with torch.no_grad():
-                results = embedd_model(batch_tokens, repr_layers=[33], return_contacts=False)
-            embedds = results["representations"][33].to(DEVICE)
+            embedds = get_esm_embedd(seq)
         # get msa here
         elif FEATURES == "msa":
             pass 
@@ -131,35 +134,48 @@ for _ in range(NUM_BATCHES):
         else:
             pass
 
-        # predict
-        distogram = model(seq, msa = msa, embedds = embedds, mask = mask)
+        # elongate inputs by a factor of 3 : N-term, C-alpha C-term
+        back = 3
+        seq  = repeat(seq, 'b l -> b l back', back = back)
+        seq  = rearrange(seq, 'b l back -> b (l back)')
+        seq_pos = repeat(torch.arange(seq.shape[-1]) % back, 'lback -> b lback', l=seq.shape[0])
+        mask = repeat(mask, 'b l -> b l back', back = back)
+        mask = rearrange(mask, 'b l back -> b (l back)')
+        if FEATURES == "msa":
+            msa = repeat(msa, 'b l d -> b l back d', back = back)
+            msa = rearrange(msa, 'b l back d -> b (l back) d')
+        if FEATURES == "esm": 
+            embedds = repeat(embedds, 'b l d -> b l back d', back = back)
+            embedds = rearrange(embedds, 'b l back d -> b (l back) d')
 
-        # convert to 3d
+        # predict - out is (batch, L*3, 3)
+        distogram = model([seq, seq_pos], msa = msa, embedds = embedds, mask = mask) 
+
+        # convert to 3d (batch, N, N, d) -> (batch, N, N) -> (batch, N, 3)
         distances, weights = center_distogram_torch(distogram)
 
-
-        coords_3d, stress= MDScaling(distances, 
+        coords_3d, stress = MDScaling(distances, 
             weights,
             iters = 200, 
             fix_mirror = 5, 
             N_mask = N_mask,
             CA_mask = CA_mask
-        ) # (3, N)
+        ) 
         coords_3d = rearrange(coords_3d, 'd n -> () n d')
 
-        ## TODO: build whole sidechain
-        sidechain_3d = build_sidechain(seq, coords_3d) # (batch, l, c, d)
+        ## TODO: build whole sidechain coords. not just container
+        sidechain_3d = build_sidechain(seq, coords_3d, force=True) # (batch, l, c, d)
         sidechain_3d = rearrange(sidechain_3d, 'b l c d -> b (l c) d')
         
         ## refine
         atom_tokens = torch.ones(*mask.shape) # sample tokens for now
-        refined = refiner(atom_tokens, sidechain_3d[cloud_mask], mask=mask, return_type=1) # (batch, N, 3)
+        refined = refiner(atom_tokens, sidechain_3d[cloud_mask], mask=chain_mask, return_type=1) # (batch, N, 3)
 
         # rotate / align
         coords_aligned = Kabsch(refined, coords[cloud_mask])
 
-        # loss
-        loss = torch.sqrt(criterion(coords_aligned[mask], coords[mask])) + \
+        # loss - RMSE + distogram_dispersion
+        loss = torch.sqrt(criterion(coords_aligned[chain_mask], coords[chain_mask])) + \
                dispersion_weight * torch.norm( (1/weights)-1 )
 
         loss.backward()

--- a/train_end2end.py
+++ b/train_end2end.py
@@ -168,8 +168,9 @@ for _ in range(NUM_BATCHES):
         sidechain_3d = rearrange(sidechain_3d, 'b l c d -> b (l c) d')
         
         ## refine
-        atom_tokens = torch.ones(*mask.shape) # sample tokens for now
-        refined = refiner(atom_tokens, sidechain_3d[cloud_mask], mask=chain_mask, return_type=1) # (batch, N, 3)
+        # sample tokens for now based on indices
+        atom_tokens = repeat(torch.arange(cloud_mask.shape[-1]), 'l -> b l', b=mask.shape[0]) % NUM_COORDS_PER_RES
+        refined = refiner(atom_tokens[cloud_mask], sidechain_3d[cloud_mask], mask=chain_mask, return_type=1) # (batch, N, 3)
 
         # rotate / align
         coords_aligned = Kabsch(refined, coords[cloud_mask])

--- a/train_end2end.py
+++ b/train_end2end.py
@@ -138,7 +138,7 @@ for _ in range(NUM_BATCHES):
         distances, weights = center_distogram_torch(distogram)
 
 
-        coords_3d = MDScaling(distances, 
+        coords_3d, stress= MDScaling(distances, 
             weights,
             iters = 200, 
             fix_mirror = 5, 

--- a/utils.py
+++ b/utils.py
@@ -120,9 +120,13 @@ def scn_cloud_mask(scn_seq, bool=True):
         Inputs: 
         * scn_seq: (batch, length) sequence as provided by Sidechainnet package
         * bool: whether to return as array of idxs or boolean values
-        Outputs: (batch, length, NUM_COORDS_PER_RES) boolean mask
+        * mask: (batch, length). current mask to build a custom chain_mask 
+        Outputs: (batch, length, NUM_COORDS_PER_RES) boolean mask 
     """
+    # scaffolds 
     mask = torch.zeros(*scn_seq.shape, NUM_COORDS_PER_RES, device=snc_seq.device)
+    chain_mask = []
+    # fill 
     for n in range(len(masks)):
         for i,aa in enumerate(scn_seq.cpu().numpy()):
             # get num of atom positions - backbone is 4: ...N-C-C(=O)...
@@ -165,7 +169,7 @@ def sidechain_3d(seq, backbone, n_atoms=NUM_COORDS_PER_RES,
     for i,token in enumerate(seq):
         # position C-beta
         # 
-        # # get location of (=O) spanding from C-term
+        # # get location of (=O) spanding from previous C-term
         #
         # # get tetrahedral conformation of C-alpha, find closest to (=O), exploit D-aa
         #


### PR DESCRIPTION
* fixes `model = esm...` to `embedd_model = esm...`
* se3 as refiner in `train_end2end.py`
* better masking
* adding sidechain generation wrapper. creates the shape for now, will work on it in near future
* minor substitutions in favour of einops
* input elongation