### PR TITLE
Predicting sidechain now

### DIFF
--- a/alphafold2_pytorch/utils.py
+++ b/alphafold2_pytorch/utils.py
@@ -258,8 +258,8 @@ def scn_atom_embedd(scn_seq):
     # do loop in cpu
     scn_seq = scn_seq.cpu()
     for i,seq in enumerate(scn_seq):
-        batch_tokens.append( torch.tensor([CUSTOM_INFO[k]["atom_id_embedd"] \
-                                           for k in seq]).long().to(device).unsqueeze(0) )
+        batch_tokens.append( torch.tensor([CUSTOM_INFO[VOCAB.int2char(aa.item())]["atom_id_embedd"] \
+                                           for aa in seq]).long().to(device).unsqueeze(0) )
     batch_tokens = torch.cat(batch_tokens, dim=0)
     return batch_tokens
 

--- a/tests/test_attention.py
+++ b/tests/test_attention.py
@@ -1,5 +1,6 @@
 import torch
 from alphafold2_pytorch.alphafold2 import Alphafold2
+from alphafold2_pytorch.utils import *
 
 def test_main():
     model = Alphafold2(
@@ -88,14 +89,14 @@ def test_coords_se3():
     msa = torch.randint(0, 21, (2, 5, 32))
     msa_mask = torch.ones_like(msa).bool()
 
-    coords, _ = model(
+    coords = model(
         seq,
         msa,
         mask = mask,
         msa_mask = msa_mask
     )
 
-    assert coords.shape == (2, 16 * 3, 3), 'must output coordinates'
+    assert coords.shape == (2, 16 * 14, 3), 'must output coordinates'
 
 def test_coords_se3_backwards():
     model = Alphafold2(
@@ -140,14 +141,25 @@ def test_coords_En():
     msa = torch.randint(0, 21, (2, 5, 32))
     msa_mask = torch.ones_like(msa).bool()
 
-    coords, _ = model(
+    coords = model(
         seq,
         msa,
         mask = mask,
         msa_mask = msa_mask
     )
+    # get masks : cloud is all points in prot. chain is all for which we have labels
+    cloud_mask = scn_cloud_mask(seq)
+    cloud_mask = scn_cloud_mask(seq, boolean = True)
+    flat_cloud_mask = rearrange(cloud_mask, 'b l c -> b (l c)')
+    chain_mask = (mask.unsqueeze(-1) * cloud_mask)
+    flat_chain_mask = rearrange(chain_mask, 'b l c -> b (l c)')
 
-    assert coords.shape == (2, 16 * 3, 3), 'must output coordinates'
+    # put in sidechainnet format
+    wrapper = torch.zeros(*cloud_mask.shape, 3).to(coords.device).type(coords.type())
+    wrapper[cloud_mask] = coords[flat_cloud_mask]
+
+    assert wrapper[chain_mask].shape == coords[flat_chain_mask].shape, 'must output coordinates'
+
 
 def test_coords_En_backwards():
     model = Alphafold2(


### PR DESCRIPTION
* initialize all sidechain points to C_beta (if present) or C_alpha (if c_beta not present)
* passes all sidechain to the refiner
* reverts to the previous version if after doing the refinement

```python
# get masks : cloud is all points in prot. chain is all for which we have labels
cloud_mask = scn_cloud_mask(seq)
cloud_mask = scn_cloud_mask(seq, boolean = True)
flat_cloud_mask = rearrange(cloud_mask, 'b l c -> b (l c)')
chain_mask = (mask.unsqueeze(-1) * cloud_mask)
flat_chain_mask = rearrange(chain_mask, 'b l c -> b (l c)')

# put in sidechainnet format
wrapper = torch.zeros(*cloud_mask.shape, 3).to(coords.device).type(coords.type())
wrapper[cloud_mask] = coords[flat_cloud_mask]

backbone_coords = wrapper[..., :3, :]
```